### PR TITLE
Add out of the box swagger frontend for testing

### DIFF
--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -1,0 +1,28 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:59427/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "WebApi": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:59436/"
+    }
+  }
+}

--- a/Startup.cs
+++ b/Startup.cs
@@ -8,6 +8,8 @@ using Microsoft.IdentityModel.Tokens;
 using System.Text;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Filters;
+using Swashbuckle.AspNetCore.Swagger;
 
 namespace WebApi
 {
@@ -51,6 +53,20 @@ namespace WebApi
                 };
             });
 
+            // configure swagger (only required for testing)
+            services.AddSwaggerGen(options =>
+            {
+                options.SwaggerDoc("v1", new Info { Title = "WebApi", Version = "v1" });
+                options.AddSecurityDefinition("oauth2", new ApiKeyScheme
+                {
+                    Description = "Standard Authorization header using the Bearer scheme. Example: \"bearer {token}\"",
+                    In = "header",
+                    Name = "Authorization",
+                    Type = "apiKey"
+                });
+                options.OperationFilter<SecurityRequirementsOperationFilter>();
+            });
+
             // configure DI for application services
             services.AddScoped<IUserService, UserService>();
         }
@@ -65,7 +81,11 @@ namespace WebApi
                 .AllowAnyHeader());
 
             app.UseAuthentication();
-            
+
+            // swagger (only required for testing)
+            app.UseSwagger();
+            app.UseSwaggerUI(c => { c.SwaggerEndpoint("/swagger/v1/swagger.json", "API V1"); });
+
             app.UseMvc();
         }
     }

--- a/WebApi.csproj
+++ b/WebApi.csproj
@@ -4,5 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="4.5.5" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
As I've struggled a bit with testing the authentication/authorization mechanism, I propose this PR which offers an easy way to test without having to use external tools.

To test from VS:
- Open solution and start debugging using the IIS Express profile

Positive:
- In the Swagger frontend which is being shown by default in the browser, autheticate with username=admin; password=admin (the remaining properties are not being used)
![image](https://user-images.githubusercontent.com/275379/54770111-e3fa7b80-4c02-11e9-9380-21a812766528.png)
- Copy the token contained in the response
- Click on the Authorize button in the upper right and enter the value 'bearer {token}' and click on Authorize
- Try the method to get users -> You get a result
![image](https://user-images.githubusercontent.com/275379/54770393-68e59500-4c03-11e9-8caf-917f2b863926.png)

Negative:
- Remove the previously set authorization (Authorize -> Logout) or set an invalid bearer Authorization header
- Try the method to get users -> You get a 401 unauthorized response:
![image](https://user-images.githubusercontent.com/275379/54770501-a5b18c00-4c03-11e9-8eb7-8b0bc21d5978.png)

Btw thanks a lot for your examples, I'll use them in an open source backend I'm currently working on.