### PR TITLE
Authorize using IAuthorizationService

### DIFF
--- a/Policies.cs
+++ b/Policies.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace WebApi
+{
+    public struct Policies
+    {
+        public const string IsOwner = "IsOwner";
+    }
+}

--- a/Startup.cs
+++ b/Startup.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using System.Security.Claims;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -8,6 +9,7 @@ using Microsoft.IdentityModel.Tokens;
 using System.Text;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Mvc;
+using WebApi.Entities;
 
 namespace WebApi
 {
@@ -49,6 +51,17 @@ namespace WebApi
                     ValidateIssuer = false,
                     ValidateAudience = false
                 };
+            });
+
+            // configure policies
+            services.AddAuthorization(options =>
+            {
+                options.AddPolicy(Policies.IsOwner, policy =>
+                    policy.RequireAssertion(ctx =>
+                    {
+                        var userId = ctx.Resource.ToString();
+                        return ctx.User.HasClaim(claim => ctx.User.IsInRole(Role.Admin) || Equals(claim.Type, ClaimTypes.Name) && Equals(claim.Value, userId));
+                    }));
             });
 
             // configure DI for application services


### PR DESCRIPTION
I propose this change to allow better reusability when having to authorize according to parameters passed to controller methods.

Changes:
- Moved code authorizing, based on parameters, from controller method to policy
- Use IAuthorizationService and specify policy to use in controller
- Slightly change behavior when calling UserController.GetById: Return Forbidden instead of NotFound when calling the method and not being authorized